### PR TITLE
Fixing issue with ' character

### DIFF
--- a/items/items.mdx
+++ b/items/items.mdx
@@ -1,6 +1,6 @@
 ---
 title: Items and Equipment
-description: 'Comprehensive information about Longvinter's items and equipment.'
+description: "Comprehensive information about Longvinter's items and equipment."
 icon: 'sack-xmark'
 ---
 


### PR DESCRIPTION
Item page doesn't work due to not escaping a quotation. Switched to double quotes to be more inline with other pages.